### PR TITLE
feat: add file(json) format & credentialKey option

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -22,6 +22,7 @@ Any comments that are immediately before a "variable declaration" will be evalua
 - [`link`](#link)
 - [`default`](#default)
 - [`configurable`](#configurable)
+- [`credentialKey`](#credentialKey)
 
 These comments can be used in any order as long as they are right before the variable declaration with no empty line before it.
 
@@ -286,6 +287,35 @@ PORT=8080
     "format": "text",
     "configurable": false,
     "default": "8080"
+  }
+]
+```
+
+### `credentialKey`
+
+The `credentialKey` option is used with `file(json)` formatted variables to specify which field of the specified file's JSON content contains authentication credentials.
+
+**Default:** `null`
+
+**Example `.env` file:**
+
+```bash
+# description: The authentication JSON file
+# format: file(json)
+# credentialKey: auth
+AUTH_JSON=auth.json
+```
+
+**Parsed Result (with omitted default values):**
+
+```json
+[
+  {
+    "key": "AUTH_JSON",
+    "description": "The authentication JSON file",
+    "format": "file(json)",
+    "credentialKey": "auth",
+    "default": "auth.json"
   }
 ]
 ```

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -22,7 +22,7 @@ Any comments that are immediately before a "variable declaration" will be evalua
 - [`link`](#link)
 - [`default`](#default)
 - [`configurable`](#configurable)
-- [`credentialKey`](#credentialKey)
+- [`contentKey`](#contentKey)
 
 These comments can be used in any order as long as they are right before the variable declaration with no empty line before it.
 
@@ -61,7 +61,7 @@ Valid values are:
 - `secret` (the same as text but UIs might decide to hide the user input)
 - `list(<X>)` (a comma separated list of values, where `<X>` defines any of the formats above). Example: `list(email)` for `support@twilio.com,open-source@twilio.com`. Use `text` for any type
 - `map(<X>,<Y>)` (a comma and semicolon separted list. often used for key value pairs. `<X>` and `<Y>` represent the format for the key and value). Example: `map(email,phone_number)` for: `help@twilio.com,+1222333444;support@twilio.com,+13334445555`
-- `file(<X>)` (the path to a file in format `<X>`, which currently only supports `json`). Example: `file(json)` for `config/test.json`
+- `file(<X>)` (the path to a file in format `<X>`, which currently only supports `json`). Example: `file(json)` for `/config/test.json`
 
 **Default:** `text`
 
@@ -291,9 +291,9 @@ PORT=8080
 ]
 ```
 
-### `credentialKey`
+### `contentKey`
 
-The `credentialKey` option is used with `file(json)` formatted variables to specify which field of the specified file's JSON content contains authentication credentials.
+The `contentKey` option is used with `file(json)` formatted variables to specify a required field that will contain a pointer to the user-supplied file content. This field is currently only used by Twilio CodeExchange.
 
 **Default:** `null`
 
@@ -302,8 +302,8 @@ The `credentialKey` option is used with `file(json)` formatted variables to spec
 ```bash
 # description: The authentication JSON file
 # format: file(json)
-# credentialKey: auth
-AUTH_JSON=auth.json
+# contentKey: AUTH_JSON_CONTENT
+AUTH_JSON=/auth.json
 ```
 
 **Parsed Result (with omitted default values):**
@@ -314,8 +314,8 @@ AUTH_JSON=auth.json
     "key": "AUTH_JSON",
     "description": "The authentication JSON file",
     "format": "file(json)",
-    "credentialKey": "auth",
-    "default": "auth.json"
+    "contentKey": "AUTH_JSON_CONTENT",
+    "default": "/auth.json"
   }
 ]
 ```
@@ -382,11 +382,12 @@ type BaseVariableFormat =
   | 'integer'
   | 'number'
   | 'secret';
+type BaseFileFormat = 'json';
 type VariableFormat =
   | BaseVariableFormat
   | ListFormat<BaseVariableFormat>
   | MapFormat<BaseVariableFormat, BaseVariableFormat>
-  | FileFormat<'json'>;
+  | FileFormat<BaseFileFormat>;
 
 type VariableDeclaration = {
   key: string;

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -60,6 +60,7 @@ Valid values are:
 - `secret` (the same as text but UIs might decide to hide the user input)
 - `list(<X>)` (a comma separated list of values, where `<X>` defines any of the formats above). Example: `list(email)` for `support@twilio.com,open-source@twilio.com`. Use `text` for any type
 - `map(<X>,<Y>)` (a comma and semicolon separted list. often used for key value pairs. `<X>` and `<Y>` represent the format for the key and value). Example: `map(email,phone_number)` for: `help@twilio.com,+1222333444;support@twilio.com,+13334445555`
+- `file(<X>)` (the path to a file in format `<X>`, which currently only supports `json`). Example: `file(json)` for `config/test.json`
 
 **Default:** `text`
 
@@ -354,7 +355,8 @@ type BaseVariableFormat =
 type VariableFormat =
   | BaseVariableFormat
   | ListFormat<BaseVariableFormat>
-  | MapFormat<BaseVariableFormat, BaseVariableFormat>;
+  | MapFormat<BaseVariableFormat, BaseVariableFormat>
+  | FileFormat<'json'>;
 
 type VariableDeclaration = {
   key: string;

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -356,6 +356,20 @@ describe('parse', () => {
       ]);
     });
 
+    test('rejects file(json) format without contentKey', () => {
+      const file = stripIndent`
+      # Test file
+
+      # description: The authentication JSON file
+      # format: file(json)
+      AUTH_JSON=/auth.json
+
+      # description: Your Twilio Auth Token
+      TWILIO_AUTH_TOKEN=
+    `;
+      expect(() => parse(file)).toThrowError();
+    });
+
     test('recognizes format comment', () => {
       const file = stripIndent`
       # Test file
@@ -402,6 +416,7 @@ describe('parse', () => {
 
       # description: config file
       # format: file(json)
+      # contentKey: AUTH_JSON_CONTENT
       CONFIG_FILE_PATH=/config/test.json
     `;
       const result = parse(file);
@@ -480,6 +495,7 @@ describe('parse', () => {
           key: 'CONFIG_FILE_PATH',
           description: 'config file',
           format: 'file(json)',
+          contentKey: 'AUTH_JSON_CONTENT',
           default: '/config/test.json',
         },
       ]);

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -325,14 +325,14 @@ describe('parse', () => {
       ]);
     });
 
-    test('recognizes credentialKey comment', () => {
+    test('recognizes contentKey comment', () => {
       const file = stripIndent`
       # Test file
 
       # description: The authentication JSON file
       # format: file(json)
-      # credentialKey: auth
-      AUTH_JSON=auth.json
+      # contentKey: AUTH_JSON_CONTENT
+      AUTH_JSON=/auth.json
 
       # description: Your Twilio Auth Token
       TWILIO_AUTH_TOKEN=
@@ -344,8 +344,8 @@ describe('parse', () => {
           key: 'AUTH_JSON',
           description: 'The authentication JSON file',
           format: 'file(json)',
-          credentialKey: 'auth',
-          default: 'auth.json',
+          contentKey: 'AUTH_JSON_CONTENT',
+          default: '/auth.json',
         },
         {
           ...DEFAULT_ENTRY,
@@ -402,7 +402,7 @@ describe('parse', () => {
 
       # description: config file
       # format: file(json)
-      CONFIG_FILE_PATH=config/test.json
+      CONFIG_FILE_PATH=/config/test.json
     `;
       const result = parse(file);
       expect(result.variables).toEqual([
@@ -480,7 +480,7 @@ describe('parse', () => {
           key: 'CONFIG_FILE_PATH',
           description: 'config file',
           format: 'file(json)',
-          default: 'config/test.json',
+          default: '/config/test.json',
         },
       ]);
     });

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -368,6 +368,10 @@ describe('parse', () => {
       # description: address book
       # format: map(text,phone_number)
       ADDRESS_BOOK=dom,+12223334444;phil,+13334445555
+
+      # description: config file
+      # format: file(json)
+      CONFIG_FILE_PATH=config/test.json
     `;
       const result = parse(file);
       expect(result.variables).toEqual([
@@ -440,6 +444,13 @@ describe('parse', () => {
           format: 'map(text,phone_number)',
           default: 'dom,+12223334444;phil,+13334445555',
         },
+        {
+          ...DEFAULT_ENTRY,
+          key: 'CONFIG_FILE_PATH',
+          description: 'config file',
+          format: 'file(json)',
+          default: 'config/test.json',
+        },
       ]);
     });
 
@@ -483,6 +494,22 @@ describe('parse', () => {
       # format: nest_list(phone_number,boolean)
       TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       
+      # description: Your Twilio Auth Token
+      # format: secret
+      TWILIO_AUTH_TOKEN=
+    `;
+
+      expect(() => parse(file)).toThrowError();
+    });
+
+    test('handles invalid file format specifiers', () => {
+      const file = stripIndent`
+      # Test file
+
+      # description: A Config File
+      # format: file(unknown)
+      CONFIG=test
+
       # description: Your Twilio Auth Token
       # format: secret
       TWILIO_AUTH_TOKEN=

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -325,6 +325,37 @@ describe('parse', () => {
       ]);
     });
 
+    test('recognizes credentialKey comment', () => {
+      const file = stripIndent`
+      # Test file
+
+      # description: The authentication JSON file
+      # format: file(json)
+      # credentialKey: auth
+      AUTH_JSON=auth.json
+
+      # description: Your Twilio Auth Token
+      TWILIO_AUTH_TOKEN=
+    `;
+      const result = parse(file);
+      expect(result.variables).toEqual([
+        {
+          ...DEFAULT_ENTRY,
+          key: 'AUTH_JSON',
+          description: 'The authentication JSON file',
+          format: 'file(json)',
+          credentialKey: 'auth',
+          default: 'auth.json',
+        },
+        {
+          ...DEFAULT_ENTRY,
+          key: 'TWILIO_AUTH_TOKEN',
+          description: 'Your Twilio Auth Token',
+          default: null,
+        },
+      ]);
+    });
+
     test('recognizes format comment', () => {
       const file = stripIndent`
       # Test file

--- a/src/__tests__/validators.test.ts
+++ b/src/__tests__/validators.test.ts
@@ -5,6 +5,7 @@ import {
   validateInteger,
   validateList,
   validateMap,
+  validateFile,
   validateNumber,
   validatePhoneNumber,
   validateSid,
@@ -241,6 +242,39 @@ describe('validateMap', () => {
   });
 });
 
+describe('validateFile', () => {
+  test('should handle json files', () => {
+    expect(validateFile('file(json)', 'testFile.json')).toEqual(true);
+  });
+
+  test('should reject unknown file types', () => {
+    expect(validateFile('file(unknown)', 'testFile')).toEqual(
+      'Invalid file format value. Received "unknown"'
+    );
+  });
+
+  test('should reject absolute file paths', () => {
+    expect(validateFile('file(json)', '/testFile')).toEqual(
+      'Please enter a relative path.'
+    );
+  });
+
+  test('should reject paths containing ".."', () => {
+    expect(validateFile('file(json)', '../testFile')).toEqual(
+      `Please enter a path that does not include '..'.`
+    );
+    expect(validateFile('file(json)', 'directory/../testFile')).toEqual(
+      `Please enter a path that does not include '..'.`
+    );
+    expect(validateFile('file(json)', '../..')).toEqual(
+      `Please enter a path that does not include '..'.`
+    );
+    expect(validateFile('file(json)', '..')).toEqual(
+      `Please enter a path that does not include '..'.`
+    );
+  });
+});
+
 describe('getValidator', () => {
   test('returns the base validator', () => {
     expect(getValidator('text').name).toEqual('baseValidator');
@@ -255,9 +289,10 @@ describe('getValidator', () => {
     expect(getValidator('number').name).toEqual('validateNumber');
   });
 
-  test('returns validator functions for list and map', () => {
+  test('returns validator functions for list, map, and file', () => {
     expect(typeof getValidator('list(text)')).toEqual('function');
     expect(typeof getValidator('map(text,text)')).toEqual('function');
+    expect(typeof getValidator('file(json)')).toEqual('function');
   });
 
   test('returns baseValidator for unknown formats', () => {

--- a/src/__tests__/validators.test.ts
+++ b/src/__tests__/validators.test.ts
@@ -244,7 +244,7 @@ describe('validateMap', () => {
 
 describe('validateFile', () => {
   test('should handle json files', () => {
-    expect(validateFile('file(json)', 'testFile.json')).toEqual(true);
+    expect(validateFile('file(json)', '/testFile.json')).toEqual(true);
   });
 
   test('should reject unknown file types', () => {
@@ -253,23 +253,23 @@ describe('validateFile', () => {
     );
   });
 
-  test('should reject absolute file paths', () => {
+  test('should reject paths with the wrong file extension', () => {
     expect(validateFile('file(json)', '/testFile')).toEqual(
-      'Please enter a relative path.'
+      `Please enter a filename that ends with '.json'.`
+    );
+    expect(validateFile('file(json)', '/testFile.txt')).toEqual(
+      `Please enter a filename that ends with '.json'.`
     );
   });
 
   test('should reject paths containing ".."', () => {
-    expect(validateFile('file(json)', '../testFile')).toEqual(
+    expect(validateFile('file(json)', '../testFile.json')).toEqual(
       `Please enter a path that does not include '..'.`
     );
-    expect(validateFile('file(json)', 'directory/../testFile')).toEqual(
+    expect(validateFile('file(json)', 'directory/../testFile.json')).toEqual(
       `Please enter a path that does not include '..'.`
     );
-    expect(validateFile('file(json)', '../..')).toEqual(
-      `Please enter a path that does not include '..'.`
-    );
-    expect(validateFile('file(json)', '..')).toEqual(
+    expect(validateFile('file(json)', '../../testFile.json')).toEqual(
       `Please enter a path that does not include '..'.`
     );
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,6 +34,7 @@ export type VariableDeclaration = {
   configurable: boolean;
   hasExplicitDescription?: boolean;
   hasAnyComment?: boolean;
+  credentialKey: string | null;
 };
 
 export type ParseResult = {
@@ -49,6 +50,7 @@ export const DEFAULT_ENTRY: VariableDeclaration = {
   link: null,
   default: null,
   configurable: true,
+  credentialKey: null,
 };
 
 const INVALID_DECLARATION_CHARACTERS = /[^a-zA-Z1-9_]/i;
@@ -211,6 +213,9 @@ export function parseCommentLine(
   } else if (line.startsWith('configurable:')) {
     const val = textToBoolean(removePrefix('configurable:', line));
     addedInfo.configurable = val;
+  } else if (line.startsWith('credentialKey:')) {
+    const val = trim(removePrefix('credentialKey:', line));
+    addedInfo.credentialKey = val;
   } else {
     if (!currentDeclaration.hasExplicitDescription) {
       addedInfo.description = currentDeclaration.description

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -17,6 +17,7 @@ export const VALID_FILE_FORMATS = ['json'] as const;
 export type BaseVariableFormat = typeof VALID_BASE_FORMATS[number];
 export type ListFormat = string;
 export type MapFormat = string;
+export type BaseFileFormat = typeof VALID_FILE_FORMATS[number];
 export type FileFormat = string;
 export type VariableFormat =
   | BaseVariableFormat
@@ -34,7 +35,7 @@ export type VariableDeclaration = {
   configurable: boolean;
   hasExplicitDescription?: boolean;
   hasAnyComment?: boolean;
-  credentialKey: string | null;
+  contentKey: string | null;
 };
 
 export type ParseResult = {
@@ -50,7 +51,7 @@ export const DEFAULT_ENTRY: VariableDeclaration = {
   link: null,
   default: null,
   configurable: true,
-  credentialKey: null,
+  contentKey: null,
 };
 
 const INVALID_DECLARATION_CHARACTERS = /[^a-zA-Z1-9_]/i;
@@ -129,11 +130,11 @@ const validFileFormats: string[] = [...VALID_FILE_FORMATS];
  * Extracts the format wrapped in `file()` or throws an error if it's an invalid format
  * @param format a format string wrapped with `file()`
  */
-export function extractFileFormat(format: string): BaseVariableFormat {
+export function extractFileFormat(format: string): BaseFileFormat {
   let fileValue = removePrefix('file(', format);
   fileValue = fileValue.substr(0, fileValue.length - 1).trim();
   if (validFileFormats.includes(fileValue)) {
-    return fileValue as BaseVariableFormat;
+    return fileValue as BaseFileFormat;
   } else {
     throw new Error(`Invalid file format value. Received "${fileValue}"`);
   }
@@ -213,9 +214,9 @@ export function parseCommentLine(
   } else if (line.startsWith('configurable:')) {
     const val = textToBoolean(removePrefix('configurable:', line));
     addedInfo.configurable = val;
-  } else if (line.startsWith('credentialKey:')) {
-    const val = trim(removePrefix('credentialKey:', line));
-    addedInfo.credentialKey = val;
+  } else if (line.startsWith('contentKey:')) {
+    const val = trim(removePrefix('contentKey:', line));
+    addedInfo.contentKey = val;
   } else {
     if (!currentDeclaration.hasExplicitDescription) {
       addedInfo.description = currentDeclaration.description

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -141,6 +141,18 @@ export function extractFileFormat(format: string): BaseFileFormat {
 }
 
 /**
+ * Checks that all values in a VariableDeclaration that depend on other values
+ * have those dependencies fulfilled, or throws an error if a value's dependency
+ * is missing.
+ * @param declaration a complete VariableDeclaration
+ */
+export function checkDependentValues(declaration: VariableDeclaration) {
+  if (declaration.format.startsWith('file(') && !declaration.contentKey) {
+    throw new Error('file(json) format variables require a contentKey value');
+  }
+}
+
+/**
  * Parses string to check if it's a valid format. If it isn't it will throw an error. Otherwise it will return a sanitized version
  * @param text string to validate as format
  */
@@ -292,6 +304,7 @@ export function parse(envFileContent: string): ParseResult {
       );
       delete fullVariableData.hasExplicitDescription;
       delete fullVariableData.hasAnyComment;
+      checkDependentValues(fullVariableData);
       variables.push({ ...fullVariableData });
       outputTemplateLines.push(
         `${fullVariableData.key}={{${fullVariableData.key}}}`

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -4,6 +4,7 @@ import {
   BaseVariableFormat,
   extractListFormat,
   extractMapFormats,
+  extractFileFormat,
 } from './parser';
 
 const SID_REGEX = /^[A-Z]{2}[a-f0-9]{32}$/;
@@ -189,6 +190,43 @@ export function validateMap(format: string, input: string): boolean | string {
 }
 
 /**
+ * Verifies that a file path is relative and does not contain ..
+ * @param input path string to verify
+ */
+export function validateFilePath(input: string): boolean | string {
+  if (input.startsWith('/')) {
+    return 'Please enter a relative path.';
+  }
+
+  if (
+    input
+      .trim()
+      .split('/')
+      .includes('..')
+  ) {
+    return `Please enter a path that does not include '..'.`;
+  }
+
+  return true;
+}
+
+/**
+ * Validates the input using a file format including validating the input path
+ *
+ * @param format Format string wrapped in file()
+ * @param input input to validate
+ */
+export function validateFile(format: string, input: string): boolean | string {
+  try {
+    extractFileFormat(format);
+
+    return validateFilePath(input);
+  } catch (err) {
+    return err.message;
+  }
+}
+
+/**
  * Returns the right validator function depending on the format
  * @param format a VariableFormat string
  */
@@ -208,6 +246,12 @@ export function getValidator(
   if (format.startsWith('map(')) {
     return input => {
       return validateMap(format, input);
+    };
+  }
+
+  if (format.startsWith('file(')) {
+    return input => {
+      return validateFile(format, input);
     };
   }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -190,12 +190,15 @@ export function validateMap(format: string, input: string): boolean | string {
 }
 
 /**
- * Verifies that a file path is relative and does not contain ..
+ * Verifies that a file path has a valid extension and does not contain ..
  * @param input path string to verify
  */
-export function validateFilePath(input: string): boolean | string {
-  if (input.startsWith('/')) {
-    return 'Please enter a relative path.';
+export function validateFilePath(
+  input: string,
+  fileType: string
+): boolean | string {
+  if (!input.trim().endsWith(`.${fileType}`)) {
+    return `Please enter a filename that ends with '.${fileType}'.`;
   }
 
   if (
@@ -218,9 +221,9 @@ export function validateFilePath(input: string): boolean | string {
  */
 export function validateFile(format: string, input: string): boolean | string {
   try {
-    extractFileFormat(format);
+    const fileType = extractFileFormat(format);
 
-    return validateFilePath(input);
+    return validateFilePath(input, fileType);
   } catch (err) {
     return err.message;
   }


### PR DESCRIPTION
Adds a `file(json)` type for the `format` option, which accepts a path for its value. Said path is validated to ensure it doesn't contain a `..` path segment and that it doesn't refer to an absolute path, as a security precaution. The `file(X)` type can be parsed for other values of `X`, but as designed the parser will throw an error for values of `X` other than `json`.

Also adds a `credentialsKey` option that indicates which JSON key within a `file(json)` file's contents contains authentication credentials.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
