### PR TITLE
Add support for ENUM type using select

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -104,6 +104,21 @@ export function extractListFormat(format: string): BaseVariableFormat {
     throw new Error(`Invalid list format value. Received "${listValue}"`);
   }
 }
+                               
+/**
+ * Extracts the format wrapped in `enum()` or throws an error if it's an invalid format
+ * @param format a format string wrapped with `enum()`
+ */
+ export function extractEnumFormat(format: string): BaseVariableFormat {
+  let enumValue = removePrefix('enum(', format);
+  enumValue = enumValue.substr(0, enumValue.length - 1).trim();
+  const enumValues = enumValue.split(',');
+  if (enumValues.length > 0) {
+    return enumValue as BaseVariableFormat;
+  } else {
+    throw new Error(`Invalid enum format value. Received "${enumValue}"`);
+  }
+}
 
 /**
  * Extracts the formats wrapped in `map()` or throws an error if one is an invalid format
@@ -173,6 +188,10 @@ export function textToFormat(text: string): VariableFormat {
     // file format
     const fileValueFormat = extractFileFormat(sanitizedText);
     return `file(${fileValueFormat})`;
+  } else if (sanitizedText.startsWith('enum(') && sanitizedText.endsWith(')')) {
+    // file format
+    const enumValueFormat = extractEnumFormat(sanitizedText);
+    return `enum(${enumValueFormat})`;
   }
 
   throw new Error(`Invalid format. Received: "${text}"`);


### PR DESCRIPTION
Add a new format `enum(value1,value2,value3)` which uses select from prompts

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
